### PR TITLE
-- Change MSAA 1x MSAA  option

### DIFF
--- a/build/index.lua
+++ b/build/index.lua
@@ -1096,16 +1096,16 @@ function DirectionPressed(dir)
       end 
     elseif string.match(games[gameCounter].msaa, "2") then
       if dir == -1 then
-        games[gameCounter].msaa = "OFF"
+        games[gameCounter].msaa = "1"
       else
         games[gameCounter].msaa = "4"
-      end 
-    elseif string.match(games[gameCounter].msaa, "OFF") then
-      if dir == -1 then
-        games[gameCounter].msaa = "4"
+      end
+	elseif string.match(games[gameCounter].msaa, "1") then
+	  if dir == -1 then
+		games[gameCounter].msaa = "OFF"
       else
         games[gameCounter].msaa = "2"
-      end 
+      end
     end
   end
 end

--- a/build/index.lua
+++ b/build/index.lua
@@ -1106,6 +1106,13 @@ function DirectionPressed(dir)
       else
         games[gameCounter].msaa = "2"
       end
+		
+    elseif string.match(games[gameCounter].msaa, "OFF") then
+      if dir == -1 then
+        games[gameCounter].msaa = "4"
+      else
+        games[gameCounter].msaa = "1"
+      end 
     end
   end
 end


### PR DESCRIPTION
Modified "-- Change MSAA" section to allow for a 1x MSAA option.
This was done because setting the MSAA option to "OFF" just uses the game's default MSAA setting. 
Usage case: Setting to 1x on a game with 4x MSAA  would completely disable the MSAA effect to allow for better framerates.